### PR TITLE
Fix 21: Parent sizing + Gutters

### DIFF
--- a/__tests__/__snapshots__/masonry.test.js.snap
+++ b/__tests__/__snapshots__/masonry.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SNAPSHOT: All functionality should match prev snapshot 1`] = `
-<View>
+<View
+  onLayout={[Function]}
+>
   <RCTScrollView
     contentContainerStyle={
       Object {

--- a/__tests__/column.test.js
+++ b/__tests__/column.test.js
@@ -27,8 +27,10 @@ const mock = [
 ];
 
 test('PRIVATE FUNC: Resize dimensions per columns', () => {
-  expect(_resizeByColumns({ height: 100, width: 400}, 2)).toEqual({gutter: 7.5, height: 91.87499999999999, width: 367.49999999999994});
-  expect(_resizeByColumns({ height: 100, width: 400}, 4)).toEqual({gutter: 7.5, height: 45, width: 180});
+  // gutter 3
+  expect(_resizeByColumns({ height: 100, width: 400}, {width: 300, height: 300}, 3)).toEqual({gutter: 3, height: 24.625, width: 98.5});
+  expect(_resizeByColumns({ height: 100, width: 400}, {width: 400, height: 300}, 2)).toEqual({gutter: 4, height: 49.5, width: 198});
+  expect(_resizeByColumns({ height: 100, width: 400}, {width: 700, height: 300}, 4)).toEqual({gutter: 7, height:  42.875, width: 171.5});
 });
 
 test('PRIVATE FUNC: Render bricks properly', () => {

--- a/components/Column.js
+++ b/components/Column.js
@@ -48,10 +48,12 @@ export function _resizeImages (data, parentDimensions, nColumns) {
 export function _resizeByColumns (imgDimensions, parentDimensions, nColumns=2) {
   const { height, width } = parentDimensions;
 
-  const gutterBase = width / 100; // 1% of the width = X px
+  // The gutter is 1% of the available view width
+  const gutterBase = width / 100;
   const gutterSize = gutterBase * 1;
 
-  const columnWidths = (width / nColumns) - gutterSize;
+  // Column gutters are shared between right and left image
+  const columnWidths = (width / nColumns) - (gutterSize / 2);
   const divider = imgDimensions.width / columnWidths;
 
   const newWidth = imgDimensions.width / divider;

--- a/components/Column.js
+++ b/components/Column.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Dimensions, View, Image, TouchableHighlight } from 'react-native';
+import { View, Image, TouchableHighlight } from 'react-native';
 import styles from '../styles/main';
 
 // Takes props and returns a masonry column
@@ -7,47 +7,48 @@ export default class Column extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      images: _resizeImages(this.props.data, this.props.columns),
+      images: _resizeImages(this.props.data, this.props.parentDimensions, this.props.columns)
     };
   }
 
   componentWillReceiveProps(nextProps) {
      this.setState({
-	images: _resizeImages(nextProps.data, nextProps.columns)
+	      images: _resizeImages(nextProps.data, nextProps.parentDimensions, nextProps.columns)
       });
   }
 
   render() {
     return (
-	<View
-          style={styles.masonry__column}>
-	  {_renderBricks(this.state.images)}  
-        </View>
+      <View
+        style={styles.masonry__column}>
+          {_renderBricks(this.state.images)}
+      </View>
     )
   }
 }
 
 // Transforms an array of images with dimensions scaled according to the
 // column it is within
-// _resizeImages :: Data, nColumns -> ResizedImage
-export function _resizeImages (data, nColumns) {
+// _resizeImages :: Data, nColumns, parentDimensions -> ResizedImage
+export function _resizeImages (data, parentDimensions, nColumns) {
   return Object.keys(data).map((key) => {
     const image = data[key];
-      const imageSizedForColumn = _resizeByColumns(data[key].dimensions, nColumns);
+      const imageSizedForColumn =
+        _resizeByColumns(data[key].dimensions, parentDimensions, nColumns);
       // Return a image object that width will be equivilent to
       // the column dimension, while retaining original image properties
       return {
-	...image,
-	...imageSizedForColumn
+	       ...image,
+	       ...imageSizedForColumn
       };
     });
 }
 // Resize image while maintain aspect ratio
-// _resizeByColumns :: ImgDimensions , nColumns -> AdjustedDimensions
-export function _resizeByColumns (imgDimensions, nColumns=2) {
-  const { height, width } = Dimensions.get('window');
+// _resizeByColumns :: ImgDimensions , parentDimensions, nColumns  -> AdjustedDimensions
+export function _resizeByColumns (imgDimensions, parentDimensions, nColumns=2) {
+  const { height, width } = parentDimensions;
 
-  const gutterBase = width / 100; // 1% = X px
+  const gutterBase = width / 100; // 1% of the width = X px
   const gutterSize = gutterBase * 1;
 
   const columnWidths = (width / nColumns) - gutterSize;
@@ -68,7 +69,7 @@ export function _renderBricks (images) {
     const brick = (image.onPress) ? _getTouchableUnit(image, gutter) : _getImageTag(image, gutter);
     return brick;
   });
-}           
+}
 
 // _getImageTag :: Image, Gutter -> ImageTag
 export function _getImageTag (image, gutter = 0) {
@@ -91,4 +92,3 @@ export function _getTouchableUnit (image, gutter = 0) {
       </TouchableHighlight>
   );
 }
-

--- a/contributing.json
+++ b/contributing.json
@@ -7,7 +7,7 @@
     "subject_lines_must_be_shorter_than": 51,
     "subject_must_be_single_line": true,
     "subject_must_be_in_tense": "imperative",
-    "subject_must_start_with_case": "lower",
+    "subject_must_start_with_case": "upper",
     "subject_must_not_end_with_dot": true,
 
     "body_lines_must_be_shorter_than": 73
@@ -16,21 +16,14 @@
     "subject_cannot_be_empty": true,
     "subject_must_be_longer_than": 4,
     "subject_must_be_shorter_than": 101,
-    "subject_must_be_in_tense": "imperative",
-    "subject_must_start_with_case": "upper",
     "subject_must_not_end_with_dot": true,
 
     "body_cannot_be_empty": true,
-    "body_must_include_verification_steps": true,
-    "body_must_include_screenshot": ["html", "css"]
   },
   "issue": {
     "subject_cannot_be_empty": true,
     "subject_must_be_longer_than": 4,
     "subject_must_be_shorter_than": 101,
-    "subject_must_be_in_tense": "imperative",
-    "subject_must_start_with_case": "upper",
-    "subject_must_not_end_with_dot": true,
 
     "body_cannot_be_empty": true,
     "body_must_include_reproduction_steps": ["bug"],

--- a/example/index.ios.js
+++ b/example/index.ios.js
@@ -10,10 +10,12 @@ import {
   Text,
   ScrollView,
   View,
-  TouchableHighlight
+  TouchableHighlight,
+  Slider
 } from 'react-native';
 import Masonry from 'react-native-masonry';
-//
+
+// list of images
 const data = [
   {
     uri: 'https://s-media-cache-ak0.pinimg.com/736x/32/7f/d9/327fd98ae0146623ca8954884029297b.jpg'
@@ -79,40 +81,54 @@ const data = [
     uri: 'https://img.buzzfeed.com/buzzfeed-static/static/2015-12/30/16/enhanced/webdr04/enhanced-15965-1451509932-6.jpg'
   }
 ];
-  
+
 export default class example extends Component {
   constructor() {
     super();
     this.state = {
-      columns: 2
+      columns: 2,
+      padding: 20
     };
   }
-  
+
   render() {
     return (
-	<ScrollView>
-	   <View style={styles.center}>
-           	<Text style={{ fontWeight: '800', fontSize: 20 }}>Masonry Demo</Text>
-           </View>
-     	<View style={[styles.center, { marginTop: 10, marginBottom: 25 }]}>
-	     <TouchableHighlight style={styles.button} onPress={() => this.setState({ columns: 2 })}>
-	         <Text>2 Column</Text>
-	      </TouchableHighlight>
-	      <TouchableHighlight style={styles.button} onPress={() => this.setState({ columns: 3 })}>
-	         <Text>3 Columns</Text>
-              </TouchableHighlight>
-              <TouchableHighlight  style={styles.button} onPress={() => this.setState({ columns: 6 })}>
-	         <Text>6 Columns</Text>
-	     </TouchableHighlight>
-	     <TouchableHighlight style={styles.button} onPress={() => this.setState({ columns: 9 })}>
-	         <Text>9 Columns</Text>
-	      </TouchableHighlight>
-           </View>
-	   <View style={{height: '100%'}}>
-	     <Masonry
-                bricks={data}
-                columns={this.state.columns}/>
-	   </View>
+      <ScrollView>
+        <View style={styles.center}>
+          <Text style={{ fontWeight: '800', fontSize: 20 }}>Masonry Demo</Text>
+        </View>
+        <View style={[styles.center, { marginTop: 10, marginBottom: 25 }]}>
+          <TouchableHighlight style={styles.button} onPress={() => this.setState({ columns: 2 })}>
+            <Text>2 Column</Text>
+          </TouchableHighlight>
+          <TouchableHighlight style={styles.button} onPress={() => this.setState({ columns: 3 })}>
+            <Text>3 Columns</Text>
+          </TouchableHighlight>
+          <TouchableHighlight  style={styles.button} onPress={() => this.setState({ columns: 6 })}>
+            <Text>6 Columns</Text>
+          </TouchableHighlight>
+          <TouchableHighlight style={styles.button} onPress={() => this.setState({ columns: 9 })}>
+            <Text>9 Columns</Text>
+          </TouchableHighlight>
+        </View>
+        <View style={[styles.center, { marginTop: 10, marginBottom: 25, flexDirection: 'column'}]}>
+          <View style={{paddingLeft: 10}}>
+            <Text>Dynamically adjust padding: {this.state.padding}</Text>
+          </View>
+          <View style={{width: '100%'}}>
+            <Slider
+              style={{height: 10, margin: 10}}
+              maximumValue={40}
+              step={5}
+              value={20}
+              onValueChange={(value) => this.setState({padding: value})} />
+          </View>
+        </View>
+        <View style={{height: '100%', padding: this.state.padding}}>
+          <Masonry
+          bricks={data}
+          columns={this.state.columns}/>
+        </View>
       </ScrollView>
     );
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-masonry",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A react-native component for a masonry layout",
   "main": "./components/Masonry.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-test-renderer": "^15.5.4"
   },
   "jest": {
-    "preset": "jest-react-native"
+    "preset": "jest-react-native",
+    "modulePathIgnorePatterns": ["<rootDir>/example/"]
   }
 }


### PR DESCRIPTION
Solves issue #21 and a visual gutter bug
- Now the masonry root view will render it's sizing according to the available size instead of a global device width. This allows the masonry to be placed into nested areas or wrapped in padding.
- Gutters should now appear more equal to each other at larger widths

Verification:
- Add a view wrapper over the Masonry component with padding
- The Masonry should render properly