### PR TITLE
Order image rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 \#*\#
 *~
 .\#*
+coverage

--- a/__tests__/masonry.test.js
+++ b/__tests__/masonry.test.js
@@ -1,34 +1,18 @@
 import { Text, View, TouchableHighlight } from 'react-native';
 import React from 'react';
 // Note: test renderer must be required after react-native.
-import Masonry from '../components/Masonry';
+import Masonry, {
+  _insertIntoColumn,
+  assignObjectColumn,
+  assignObjectIndex,
+} from '../components/Masonry';
 import renderer from 'react-test-renderer';
 
-const brickSet = [
-  {
-    uri: 'https://cat1.jpg',
-    data: {
-      id: 1
-    }
-  },
-  {
-    data: {
-      routeId: 'cat-3',
-      id: 2,
-    },
-    uri: 'http://test.com/cat3.jpg',
-    onPress: (brick) => redirect(brick.routeId)
-  },
-  {
-    data: {
-      id: 3
-    },
-    uri: 'http://test.com/cat2.jpg'
-  },
-  {
-    uri: 'http://test.com/cat3.jpg'
-  }
-];
+import {
+  brickSet,
+  minimumBricks,
+} from './mocks/masonryMock';
+
 
 test('Render masonry correct', () => {
   const masonry = renderer.create(<Masonry bricks={brickSet} columns={3} />).toJSON();
@@ -48,4 +32,25 @@ test('Render masonry correct', () => {
 test('SNAPSHOT: All functionality should match prev snapshot', () => {
   const tree = renderer.create(<Masonry bricks={brickSet} columns={3} />).toJSON();
   expect(tree).toMatchSnapshot();
+});
+
+test('PRIVATE FUNC: _insertIntoColumn sorts bricks according to index of bricks array and columns', () => {
+  const nColumns = 2;
+  const assignedBricks = minimumBricks
+  .map((brick, index) => assignObjectColumn(nColumns, index, brick))
+  .map((brick, index) => assignObjectIndex(index, brick));
+
+  const expectedData = [
+    [assignedBricks[0], assignedBricks[2]], //column 0
+    [assignedBricks[1], assignedBricks[3]] //column 1
+  ];
+
+  //when
+  let expectedSorted = [];
+  assignedBricks.forEach((brick) => {
+    expectedSorted = _insertIntoColumn(brick, expectedSorted, true);
+  });
+
+  //then
+  expect(expectedSorted).toEqual(expectedData);
 });

--- a/__tests__/mocks/masonryMock.js
+++ b/__tests__/mocks/masonryMock.js
@@ -1,0 +1,41 @@
+
+export const minimumBricks = [
+  {
+    uri: 'https://cat1.jpg',
+  },
+  {
+    uri: 'https://cat2.jpg',
+  },
+  {
+    uri: 'https://cat3.jpg',
+  },
+  {
+    uri: 'https://cat4.jpg',
+  },
+];
+
+export const brickSet = [
+  {
+    uri: 'https://cat1.jpg',
+    data: {
+      id: 1
+    }
+  },
+  {
+    data: {
+      routeId: 'cat-3',
+      id: 2,
+    },
+    uri: 'http://test.com/cat3.jpg',
+    onPress: (brick) => redirect(brick.routeId)
+  },
+  {
+    data: {
+      id: 3
+    },
+    uri: 'http://test.com/cat2.jpg'
+  },
+  {
+    uri: 'http://test.com/cat3.jpg'
+  }
+];

--- a/components/Masonry.js
+++ b/components/Masonry.js
@@ -80,7 +80,7 @@ export default class Masonry extends Component {
       	(err) => console.warn('Image failed to load'),
       	(resolvedBrick) => {
       	  this.setState(state => {
-      	    const sortedData = _insertIntoColumn(resolvedBrick, state._sortedData);
+      	    const sortedData = this._insertIntoColumn(resolvedBrick, state._sortedData);
 
       	    return {
       	      dataSource: state.dataSource.cloneWithRows(sortedData),

--- a/components/Masonry.js
+++ b/components/Masonry.js
@@ -8,12 +8,12 @@ import { resolveImage } from './model';
 import Column from './Column';
 import styles from '../styles/main';
 
-// assignObjectColumns :: Number -> [Objects] -> [Objects]
-const assignObjectColumns = (nColumns, index, targetObject) => ({...targetObject, ...{ column: index % nColumns }});
+// assignObjectColumn :: Number -> [Objects] -> [Objects]
+export const assignObjectColumn = (nColumns, index, targetObject) => ({...targetObject, ...{ column: index % nColumns }});
 
 // assignObjectIndex :: (Number, Object) -> Object
 // Assigns an `index` property` from bricks={data}` for later sorting.
-const assignObjectIndex = (index, targetObject) => ({...targetObject, ...{ index }});
+export const assignObjectIndex = (index, targetObject) => ({...targetObject, ...{ index }});
 
 // containMatchingUris :: ([brick], [brick]) -> Bool
 const containMatchingUris = (r1, r2) => isEqual(r1.map(brick => brick.uri), r2.map(brick => brick.uri));
@@ -59,8 +59,9 @@ export default class Masonry extends Component {
         const newColumnCount = nextProps.columns;
         // Re-sort existing data instead of attempting to re-resolved
         const resortedData = this.state._resolvedData
-          .map((brick, index) => assignObjectColumns(newColumnCount, index, brick))
-          .reduce((sortDataAcc, resolvedBrick) => this._insertIntoColumn(resolvedBrick, sortDataAcc), []);
+          .map((brick, index) => assignObjectColumn(newColumnCount, index, brick))
+          .map((brick, index) => assignObjectIndex(index, brick))
+          .reduce((sortDataAcc, resolvedBrick) => _insertIntoColumn(resolvedBrick, sortDataAcc, this.props.sorted), []);
 
       	this.setState({
       	  dataSource: this.state.dataSource.cloneWithRows(resortedData)
@@ -73,14 +74,14 @@ export default class Masonry extends Component {
 
   resolveBricks({ bricks, columns }) {
     bricks
-      .map((brick, index) => assignObjectColumns(columns, index, brick))
+      .map((brick, index) => assignObjectColumn(columns, index, brick))
       .map((brick, index) => assignObjectIndex(index, brick))
       .map(brick => resolveImage(brick))
       .map(resolveTask => resolveTask.fork(
       	(err) => console.warn('Image failed to load'),
       	(resolvedBrick) => {
       	  this.setState(state => {
-      	    const sortedData = this._insertIntoColumn(resolvedBrick, state._sortedData);
+      	    const sortedData = _insertIntoColumn(resolvedBrick, state._sortedData, this.props.sorted);
 
       	    return {
       	      dataSource: state.dataSource.cloneWithRows(sortedData),
@@ -102,29 +103,6 @@ export default class Masonry extends Component {
     });
   }
 
-  // Returns a copy of the dataSet with resolvedBrick in correct place
-  // (resolvedBrick, dataSetA) -> dataSetB
-  _insertIntoColumn (resolvedBrick, dataSet) {
-    let dataCopy = dataSet.slice();
-    const columnIndex = resolvedBrick.column;
-    const column = dataSet[columnIndex];
-
-    if (column) {
-      // Append to existing "row"/"column"
-      const bricks = [...column, resolvedBrick]
-      if(this.props.sorted) {
-        // Sort bricks according to the index of their original array position
-        bricks = bricks.sort((a, b) => { return (a.index < b.index) ? -1 : 1; });
-      }
-      dataCopy[columnIndex] = bricks
-    } else {
-      // Pass it as a new "row" for the data source
-      dataCopy = [...dataCopy, [resolvedBrick]];
-    }
-
-    return dataCopy;
-  };
-
   render() {
     return (
   	<View onLayout={(event) => this._setParentDimensions(event)}>
@@ -142,4 +120,27 @@ export default class Masonry extends Component {
   	</View>
     )
   }
+};
+
+// Returns a copy of the dataSet with resolvedBrick in correct place
+// (resolvedBrick, dataSetA, bool) -> dataSetB
+export function _insertIntoColumn (resolvedBrick, dataSet, sorted) {
+  let dataCopy = dataSet.slice();
+  const columnIndex = resolvedBrick.column;
+  const column = dataSet[columnIndex];
+
+  if (column) {
+    // Append to existing "row"/"column"
+    const bricks = [...column, resolvedBrick]
+    if(sorted) {
+      // Sort bricks according to the index of their original array position
+      bricks = bricks.sort((a, b) => { return (a.index < b.index) ? -1 : 1; });
+    }
+    dataCopy[columnIndex] = bricks
+  } else {
+    // Pass it as a new "row" for the data source
+    dataCopy = [...dataCopy, [resolvedBrick]];
+  }
+
+  return dataCopy;
 };

--- a/example/App/Container/app.js
+++ b/example/App/Container/app.js
@@ -150,8 +150,9 @@ export default class example extends Component {
         </View>
         <View style={{height: '100%', padding: this.state.padding}}>
           <Masonry
-          bricks={data}
-          columns={this.state.columns}/>
+            sorted
+            bricks={data}
+            columns={this.state.columns}/>
         </View>
       </ScrollView>
     );

--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "16.0.0-alpha.6",
     "react-native": "0.43.0",
-    "react-native-masonry": "*"
+    "react-native-masonry": "^0.2.1"
   },
   "devDependencies": {
     "babel-jest": "19.0.0",

--- a/example/package.json
+++ b/example/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "react": "16.0.0-alpha.6",
-    "react-native": "0.43.0",
-    "react-native-masonry": "^0.2.1"
+    "react-native": "^0.43.0",
+    "react-native-masonry": "*"
   },
   "devDependencies": {
     "babel-jest": "19.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
   },
   "jest": {
     "preset": "jest-react-native",
-    "modulePathIgnorePatterns": ["<rootDir>/example/", "<rootDir>/__tests__/mocks/"]
+    "modulePathIgnorePatterns": [
+      "<rootDir>/example/",
+      "<rootDir>/__tests__/mocks/"
+    ]
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,8 @@
 | Props   | Type                     | Description                                                                                                                                                                                                                                                                                 | Default |
 |---------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
 | bricks    | array | A list of `Object:Bricks` to be passed into the row renderer. I.E:,`bricks=[{id: 1, uri: 'https://image.jpg', onPress: (brick) => this.redirect(brick.id)}, {id: 2, uri: 'https://hyper.jpg'}]` | []     |
-| columns | num                      | Desired number of columns                                                                                                                                                                                                                                                                   | 2       |
+| columns | num | Desired number of columns | 2 |
+| sorted | bool | Whether to sort `bricks` according to their index position or allow bricks to fill in as soon as the `uri` is ready. | false |
 
 ### Brick Properties
 "Bricks" are the basic building block of the masonry and are passed into the props.bricks. They essentially represent the items within each column and require a `uri` property at a minimum. However, you can freely add additional properties to the `data` property if you need access to certain data within your `brick.onPress` handler and `footer/header` renderer. The following properties are available:

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,8 @@
 3. At a minimal, declare the component in the render method prividing data for bricks
     ```js
     <Masonry
+      sorted // optional - Default: false
+      columns=4 // optional - Default: 2
       bricks=[
         { uri: 'http://image1.jpg' },
         { uri: 'http://image2.jpg' },


### PR DESCRIPTION
Per #30 I've added the ability to order images based on their index of the `data` passed to Masonry. I could envision use cases for both ordered and non so I added the prop `sorted` to Masonry to give users the option to choose.

This may not be the *best* solution but it is *a* solution. 🥇 