### PR TITLE
Allow use of custom image component instead of default Image

### DIFF
--- a/components/Brick.js
+++ b/components/Brick.js
@@ -17,14 +17,35 @@ export default function Brick (props) {
 }
 
 // _getImageTag :: Image, Gutter -> ImageTag
-export function _getImageTag (image, gutter = 0) {
-  return (
+export function _getImageTag (props, gutter = 0) {
+  const imageProps = {
+    key: props.uri,
+    source: {
+      uri: props.uri
+    },
+    resizeMethod: 'auto',
+    style: {
+       ...props.imageContainerStyle,
+
+       width: props.width,
+       height: props.height,
+       marginTop: gutter,
+    }
+  };
+
+  if (props.customImageComponent) {
+    const CustomRender = props.customImageComponent;
+    return (
+      <CustomRender
+        {...props.customImageProps}
+        {...imageProps} />
+    )
+  } else {
+    return (
       <Image
-        key={image.uri}
-        source={{ uri: image.uri }}
-        resizeMethod='auto'
-        style={{ width: image.width, height: image.height, marginTop: gutter, ...image.imageContainerStyle }} />
-  );
+        {...imageProps} />
+      );
+  }
 }
 
 // _getTouchableUnit :: Image, Number -> TouchableTag

--- a/components/Column.js
+++ b/components/Column.js
@@ -12,6 +12,8 @@ export default class Column extends Component {
     parentDimensions: PropTypes.object,
     columnKey: PropTypes.string,
     imageContainerStyle: PropTypes.object,
+    customImageComponent: PropTypes.func,
+    customImageProps: PropTypes.object
   };
 
   constructor(props) {
@@ -83,8 +85,8 @@ export default class Column extends Component {
     return bricks.map((brick, index) => {
       const gutter = (index === 0) ? 0 : brick.gutter;
       const key = `RN-MASONRY-BRICK-${brick.column}-${index}`;
-      const { imageContainerStyle } = this.props;
-      const props = { ...brick, gutter, key, imageContainerStyle };
+      const { imageContainerStyle, customImageComponent, customImageProps } = this.props;
+      const props = { ...brick, gutter, key, imageContainerStyle, customImageComponent, customImageProps };
 
       return (
         <Brick

--- a/components/Masonry.js
+++ b/components/Masonry.js
@@ -24,6 +24,8 @@ export default class Masonry extends Component {
     columns: PropTypes.number,
     sorted: PropTypes.bool,
     imageContainerStyle: PropTypes.object,
+    customImageComponent: PropTypes.func,
+    customImageProps: PropTypes.object
   };
 
   static defaultProps = {
@@ -118,6 +120,8 @@ export default class Masonry extends Component {
              columns={this.props.columns}
              parentDimensions={this.state.dimensions}
              imageContainerStyle={this.props.imageContainerStyle}
+             customImageComponent={this.props.customImageComponent}
+             customImageProps={this.props.customImageProps}
              key={`RN-MASONRY-COLUMN-${rowID}`}/> }
        />
   	</View>

--- a/example/App/Container/app.js
+++ b/example/App/Container/app.js
@@ -14,6 +14,7 @@ import {
   Image,
   Slider
 } from 'react-native';
+import FastImage from 'react-native-fast-image';
 import Masonry from 'react-native-masonry';
 
 // list of images
@@ -45,10 +46,10 @@ const data = [
     }
   },
   {
-    uri: 'https://s-media-cache-ak0.pinimg.com/736x/b1/21/df/b121df29b41b771d6610dba71834e512.jpg'
+    uri: 'https://s-media-cache-ak0.pinimg.com/736x/b1/21/df/b121df29b41b771d6610dba71834e512.jpg',
   },
   {
-    uri: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQpD8mz-2Wwix8hHbGgR-mCFQVFTF7TF7hU05BxwLVO1PS5j-rZA'
+    uri: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTQpD8mz-2Wwix8hHbGgR-mCFQVFTF7TF7hU05BxwLVO1PS5j-rZA',
   },
   {
     uri: 'https://s-media-cache-ak0.pinimg.com/736x/5a/15/0c/5a150cf9d5a825c8b5871eefbeda8d14.jpg'
@@ -152,7 +153,8 @@ export default class example extends Component {
           <Masonry
             sorted
             bricks={data}
-            columns={this.state.columns}/>
+            columns={this.state.columns}
+            customImageComponent={FastImage} />
         </View>
       </ScrollView>
     );

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -126,6 +126,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-fast-image')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules

--- a/example/android/app/src/main/java/com/example/MainApplication.java
+++ b/example/android/app/src/main/java/com/example/MainApplication.java
@@ -3,6 +3,7 @@ package com.example;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.dylanvann.fastimage.FastImageViewPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -22,7 +23,8 @@ public class MainApplication extends Application implements ReactApplication {
     @Override
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
-          new MainReactPackage()
+          new MainReactPackage(),
+            new FastImageViewPackage()
       );
     }
   };

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,3 +1,5 @@
 rootProject.name = 'example'
+include ':react-native-fast-image'
+project(':react-native-fast-image').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fast-image/android')
 
 include ':app'

--- a/example/ios/example.xcodeproj/project.pbxproj
+++ b/example/ios/example.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -36,6 +35,7 @@
 		2DCD954D1E0B4F2C00145EB5 /* exampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* exampleTests.m */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		A2071044A88B42A7AD4044A4 /* libFastImage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F0AE4CE3D3545C1B4EA167F /* libFastImage.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -255,6 +255,8 @@
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
+		F4C0E7CF4C204B7CB7B60519 /* FastImage.xcodeproj */ = {isa = PBXFileReference; name = "FastImage.xcodeproj"; path = "../node_modules/react-native-fast-image/ios/FastImage.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		3F0AE4CE3D3545C1B4EA167F /* libFastImage.a */ = {isa = PBXFileReference; name = "libFastImage.a"; path = "libFastImage.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -281,6 +283,7 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
+				A2071044A88B42A7AD4044A4 /* libFastImage.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -447,6 +450,7 @@
 				832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */,
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
+				F4C0E7CF4C204B7CB7B60519 /* FastImage.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -564,7 +568,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 610;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
@@ -972,6 +976,14 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/example.app/example";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-fast-image/ios/FastImage/**",
+				);
 			};
 			name = Debug;
 		};
@@ -989,6 +1001,14 @@
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/example.app/example";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-fast-image/ios/FastImage/**",
+				);
 			};
 			name = Release;
 		};
@@ -1007,6 +1027,10 @@
 				);
 				PRODUCT_NAME = example;
 				VERSIONING_SYSTEM = "apple-generic";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-fast-image/ios/FastImage/**",
+				);
 			};
 			name = Debug;
 		};
@@ -1024,6 +1048,10 @@
 				);
 				PRODUCT_NAME = example;
 				VERSIONING_SYSTEM = "apple-generic";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-fast-image/ios/FastImage/**",
+				);
 			};
 			name = Release;
 		};
@@ -1050,6 +1078,14 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-fast-image/ios/FastImage/**",
+				);
 			};
 			name = Debug;
 		};
@@ -1076,6 +1112,14 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.2;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/react-native-fast-image/ios/FastImage/**",
+				);
 			};
 			name = Release;
 		};
@@ -1097,6 +1141,10 @@
 				SDKROOT = appletvos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/example-tvOS.app/example-tvOS";
 				TVOS_DEPLOYMENT_TARGET = 10.1;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 			};
 			name = Debug;
 		};
@@ -1118,6 +1166,10 @@
 				SDKROOT = appletvos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/example-tvOS.app/example-tvOS";
 				TVOS_DEPLOYMENT_TARGET = 10.1;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 			};
 			name = Release;
 		};

--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "react": "16.0.0-alpha.6",
     "react-native": "^0.43.0",
+    "react-native-fast-image": "^1.0.0",
     "react-native-masonry": "*"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -28,12 +28,14 @@
 
 ## Component Props
 
-| Props   | Type                     | Description                                                                                                                                                                                                                                                                                 | Default |
-|---------|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
-| bricks    | array | A list of `Object:Bricks` to be passed into the row renderer. I.E:,`bricks=[{id: 1, uri: 'https://image.jpg', onPress: (brick) => this.redirect(brick.id)}, {id: 2, uri: 'https://hyper.jpg'}]` | []     |
-| columns | num | Desired number of columns | 2 |
-| sorted | bool | Whether to sort `bricks` according to their index position or allow bricks to fill in as soon as the `uri` is ready. | false |
-| imageContainerStyle | object | The styles object which is added to the Image component | {} |
+| Props                | Type              | Description                                                                                                                                                                                     | Default |
+|----------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| bricks               | array             | A list of `Object:Bricks` to be passed into the row renderer. I.E:,`bricks=[{id: 1, uri: 'https://image.jpg', onPress: (brick) => this.redirect(brick.id)}, {id: 2, uri: 'https://hyper.jpg'}]` | []      |
+| columns              | num               | Desired number of columns                                                                                                                                                                       | 2       |
+| sorted               | bool              | Whether to sort `bricks` according to their index position or allow bricks to fill in as soon as the `uri` is ready.                                                                            | false   |
+| imageContainerStyle  | object            | The styles object which is added to the Image component                                                                                                                                         | {}      |
+| customImageComponent | `React.Component` | Use a custom component to be rendered for the Image. This will work properly, as long as the component follows the standard interface of the react-native image component.                      |         |
+| customImageProps     | object            | Pass along additional properties to a `props.customImageComponent`.                                                                                                                             |         |
 
 ### Brick Properties
 "Bricks" are the basic building block of the masonry and are passed into the props.bricks. They essentially represent the items within each column and require a `uri` property at a minimum. However, you can freely add additional properties to the `data` property if you need access to certain data within your `brick.onPress` handler and `footer/header` renderer. The following properties are available:


### PR DESCRIPTION
As requested per: #34 #29 

This allows user to pass in a React.Component to `Masonry` which will be used to render the image component. Along with the custom component, users are able to pass along "default" properties which will propagate (`<CustomImageComponent {...props.customImageProps}>`) to each image.