### PR TITLE
Fix issues with sorting order when adding new bricsk

### DIFF
--- a/components/Masonry.js
+++ b/components/Masonry.js
@@ -76,9 +76,6 @@ export default class Masonry extends Component {
       	});
       }
     } else {
-		console.log(this.state._sortedData);
-		console.log(this.state._resolvedData);
-		console.log(nextProps);
 		this.resolveBricks(nextProps, true);
     }
   }

--- a/components/Masonry.js
+++ b/components/Masonry.js
@@ -83,50 +83,33 @@ export default class Masonry extends Component {
     }
   }
 
-	resolveBricks({ bricks, columns }, update = false) {
-		if (update) {
-			// Assign the new bricks their spots ahead of time
-			// We can utilize this to determine where to insert upon our existing
-			// Rendered masonry
-			const assignedBricks = bricks
-				  .map((brick, index) => assignObjectColumn(columns, index, brick))
-				  .map((brick, index) => assignObjectIndex(index, brick));
+	resolveBricks({ bricks, columns }, newBricks = false) {
+		// Sort bricks and place them into their respectable columns
+		const sortedBricks = bricks
+			  .map((brick, index) => assignObjectColumn(columns, index, brick))
+			  .map((brick, index) => assignObjectIndex(index, brick));
 
-			const unresolvedBricks = differenceBy(assignedBricks, this.state._resolvedData, 'uri');
-			unresolvedBricks
-				.map(brick => resolveImage(brick))
-				.map(resolveTask => resolveTask.fork(
-					(err) => console.warn('Image failed to load'),
-					(resolvedBrick) => {
-						this.setState(state => {
-							const sortedData = _insertIntoColumn(resolvedBrick, state._sortedData, this.props.sorted);
+		// Do a difference check if these are new props
+		// to only resolve what is needed
+		const unresolvedBricks = (newBricks) ?
+			  differenceBy(sortedBricks, this.state._resolvedData, 'uri') :
+			  sortedBricks;
 
-							return {
-								dataSource: state.dataSource.cloneWithRows(sortedData),
-								_sortedData: sortedData,
-								_resolvedData: [...state._resolvedData, resolvedBrick]
-							};
-						});;
-					}));
-		} else {
-			bricks
-				.map((brick, index) => assignObjectColumn(columns, index, brick))
-				.map((brick, index) => assignObjectIndex(index, brick))
-				.map(brick => resolveImage(brick))
-				.map(resolveTask => resolveTask.fork(
-					(err) => console.warn('Image failed to load'),
-					(resolvedBrick) => {
-						this.setState(state => {
-							const sortedData = _insertIntoColumn(resolvedBrick, state._sortedData, this.props.sorted);
-							console.log(sortedData);
-							return {
-								dataSource: state.dataSource.cloneWithRows(sortedData),
-								_sortedData: sortedData,
-								_resolvedData: [...state._resolvedData, resolvedBrick]
-							};
-						});;
-					}));
-		}
+		unresolvedBricks
+			.map(brick => resolveImage(brick))
+			.map(resolveTask => resolveTask.fork(
+				(err) => console.warn('Image failed to load'),
+				(resolvedBrick) => {
+					this.setState(state => {
+						const sortedData = _insertIntoColumn(resolvedBrick, state._sortedData, this.props.sorted);
+						console.log(sortedData);
+						return {
+							dataSource: state.dataSource.cloneWithRows(sortedData),
+							_sortedData: sortedData,
+							_resolvedData: [...state._resolvedData, resolvedBrick]
+						};
+					});;
+				}));
 	}
 
   _setParentDimensions(event) {

--- a/example/App/Container/app.js
+++ b/example/App/Container/app.js
@@ -18,7 +18,7 @@ import FastImage from 'react-native-fast-image';
 import Masonry from 'react-native-masonry';
 
 // list of images
-const data = [
+let data = [
   {
     data: {
       caption: 'Summer Recipies',
@@ -107,20 +107,41 @@ const data = [
   }
 ];
 
+const addData = [
+	{
+		uri: 'https://i.pinimg.com/736x/48/ee/51/48ee519a1768245ce273363f5bf05f30--kaylaitsines-dipping-sauces.jpg'
+	},
+	{
+		uri: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQGYfU5N8lsJepQyoAigiijX8bcdpahei_XqRWBzZLbxcsuqtiH'
+	},
+	{
+		uri: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSPL2GTXDuOzwuX5X7Mgwc3Vc9ZIhiMmZUhp3s1wg0oHPzSP7qC'
+	}
+];
+
 export default class example extends Component {
   constructor() {
-    super();
-    this.state = {
-      columns: 2,
-      padding: 5
-    };
+      super();
+      this.state = {
+		  columns: 2,
+		  padding: 5,
+		  data
+      };
   }
+
+	_addData = () => {
+		const appendedData = [...data, ...addData];
+		console.log(appendedData);
+		this.setState({
+			data: appendedData
+		});
+	}
 
   render() {
     return (
       <View style={{flex: 1, backgroundColor: '#f4f4f4'}}>
         <View style={[styles.center, styles.header]}>
-          <Text style={{ fontWeight: '800', fontSize: 20 }}>Masonry Demo</Text>
+			<Text style={{ fontWeight: '800', fontSize: 20 }}>Masonry Demo</Text>
         </View>
         <View style={[styles.center, styles.buttonGroup, { marginTop: 10, marginBottom: 25 }]}>
           <TouchableHighlight style={styles.button} onPress={() => this.setState({ columns: 2 })}>
@@ -135,7 +156,12 @@ export default class example extends Component {
           <TouchableHighlight style={styles.button} onPress={() => this.setState({ columns: 9 })}>
             <Text>9 Columns</Text>
           </TouchableHighlight>
-        </View>
+		</View>
+	    <View style={styles.buttonGroup, {marginLeft: 4}}>
+		  <TouchableHighlight style={styles.button} onPress={this._addData}>
+            <Text>Push New Data</Text>
+		  </TouchableHighlight>
+		</View>
         <View style={[styles.center, styles.slider, { marginTop: 10, marginBottom: 25, flexDirection: 'column'}]}>
           <View style={{paddingLeft: 10}}>
             <Text>Dynamically adjust padding: {this.state.padding}</Text>
@@ -152,7 +178,7 @@ export default class example extends Component {
         <View style={{flex: 1, flexGrow: 10, padding: this.state.padding}}>
           <Masonry
             sorted
-            bricks={data}
+            bricks={this.state.data}
             columns={this.state.columns}
             customImageComponent={FastImage} />
         </View>

--- a/example/App/Container/app.js
+++ b/example/App/Container/app.js
@@ -131,7 +131,6 @@ export default class example extends Component {
 
 	_addData = () => {
 		const appendedData = [...data, ...addData];
-		console.log(appendedData);
 		this.setState({
 			data: appendedData
 		});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-masonry",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A react-native component for a masonry layout",
   "main": "./components/Masonry.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/brh55/react-native-masonry#readme",
   "dependencies": {
     "data.task": "^3.1.1",
+    "lodash.differenceby": "^4.8.0",
     "lodash.isequal": "^4.5.0",
     "opencollective": "^1.0.3",
     "prop-types": "^15.5.8",


### PR DESCRIPTION
This should fix some issues pertaining to #61. That issue will be closed once we've been able to create reproducible environment.

But mainly this PR mainly fixes the following issues:
- Flickering associated with adding new bricks to the masonry
- Dynamically pushing data to the masonry without altering existing sort order
- Optimize to append to existing masonry and resolve only images that have not been downloaded