### PR TITLE
Cache bug fix

### DIFF
--- a/components/Brick.js
+++ b/components/Brick.js
@@ -3,54 +3,54 @@ import { View, Image, TouchableHighlight } from 'react-native';
 import Injector from 'react-native-injectable-component';
 
 export default function Brick (props) {
-  // Avoid margins for first element
-  const image = (props.onPress) ? _getTouchableUnit(props, props.gutter) : _getImageTag(props, props.gutter);
-  const footer = (props.renderFooter) ? props.renderFooter(props.data) : null;
-  const header = (props.renderHeader) ? props.renderHeader(props.data) : null;
+	// Avoid margins for first element
+	const image = (props.onPress) ? _getTouchableUnit(props, props.gutter) : _getImageTag(props, props.gutter);
+	const footer = (props.renderFooter) ? props.renderFooter(props.data) : null;
+	const header = (props.renderHeader) ? props.renderHeader(props.data) : null;
 
-  return (
-    <View key={props.brickKey}>
-      {header}
-      {image}
-      {footer}
-    </View>
-  );
+	return (
+		<View key={props.brickKey}>
+		  {header}
+		  {image}
+		  {footer}
+		</View>
+	);
 }
 
 // _getImageTag :: Image, Gutter -> ImageTag
 export function _getImageTag (props, gutter = 0) {
-  const imageProps = {
-    key: props.uri,
-    source: {
-      uri: props.uri
-    },
-    resizeMethod: 'auto',
-    style: {
-       width: props.width,
-       height: props.height,
-       marginTop: gutter,
-       ...props.imageContainerStyle,
-    }
-  };
+	const imageProps = {
+		key: props.uri,
+		source: {
+			uri: props.uri
+		},
+		resizeMethod: 'auto',
+		style: {
+			width: props.width,
+			height: props.height,
+			marginTop: gutter,
+			...props.imageContainerStyle,
+		}
+	};
 
-  return (
-    <Injector
-      defaultComponent={Image}
-      defaultProps={imageProps}
-      injectant={props.customImageComponent}
-      injectantProps={props.customImageProps} />
-  )
+	return (
+		<Injector
+		  defaultComponent={Image}
+		  defaultProps={imageProps}
+		  injectant={props.customImageComponent}
+		  injectantProps={props.customImageProps} />
+	)
 }
 
 // _getTouchableUnit :: Image, Number -> TouchableTag
 export function _getTouchableUnit (image, gutter = 0) {
-  return (
-      <TouchableHighlight
-         key={image.uri}
-         onPress={() => image.onPress(image.data)}>
-         <View>
+	return (
+		<TouchableHighlight
+          key={image.uri}
+          onPress={() => image.onPress(image.data)}>
+          <View>
             { _getImageTag(image, gutter) }
-         </View>
-      </TouchableHighlight>
-  );
+          </View>
+		</TouchableHighlight>
+	);
 }

--- a/components/Column.js
+++ b/components/Column.js
@@ -6,134 +6,134 @@ import Brick from './Brick';
 
 // Takes props and returns a masonry column
 export default class Column extends Component {
-  static propTypes = {
-    data: PropTypes.array,
-    columns: PropTypes.number,
-    parentDimensions: PropTypes.object,
-    columnKey: PropTypes.string,
-    imageContainerStyle: PropTypes.object,
-    customImageComponent: PropTypes.func,
-    customImageProps: PropTypes.object
-  };
+	static propTypes = {
+		data: PropTypes.array,
+		columns: PropTypes.number,
+		parentDimensions: PropTypes.object,
+		columnKey: PropTypes.string,
+		imageContainerStyle: PropTypes.object,
+		customImageComponent: PropTypes.func,
+		customImageProps: PropTypes.object
+	};
 
-  static defaultProps = {
-    imageContainerStyle: {},
-    spacing: 1
-  };
+	static defaultProps = {
+		imageContainerStyle: {},
+		spacing: 1
+	};
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      images: [],
-      columnWidth: 0
-    };
-  }
+	constructor(props) {
+		super(props);
+		this.state = {
+			images: [],
+			columnWidth: 0
+		};
+	}
 
-  componentWillMount() {
-    this.setState({
-      images: this._resizeImages(this.props.data, this.props.parentDimensions, this.props.columns),
-    });
-  }
+	componentWillMount() {
+		this.setState({
+			images: this._resizeImages(this.props.data, this.props.parentDimensions, this.props.columns),
+		});
+	}
 
-  componentWillReceiveProps(nextProps) {
-     this.setState({
-	      images: this._resizeImages(nextProps.data, nextProps.parentDimensions, nextProps.columns)
-      });
-  }
+	componentWillReceiveProps(nextProps) {
+		this.setState({
+			images: this._resizeImages(nextProps.data, nextProps.parentDimensions, nextProps.columns)
+		});
+	}
 
-  // Transforms an array of images with dimensions scaled according to the
-  // column it is within
-  // _resizeImages :: Data, parentDimensions. nColumns -> ResizedImage
-  _resizeImages (data, parentDimensions, nColumns) {
-    return Object.keys(data).map((key) => {
-      const image = data[key];
-        const imageSizedForColumn =
-          this._resizeByColumns(data[key].dimensions, parentDimensions, nColumns);
-        // Return a image object that width will be equivilent to
-        // the column dimension, while retaining original image properties
-        return {
-  	       ...image,
-  	       ...imageSizedForColumn
-        };
-      });
-  }
+	// Transforms an array of images with dimensions scaled according to the
+	// column it is within
+	// _resizeImages :: Data, parentDimensions. nColumns -> ResizedImage
+	_resizeImages (data, parentDimensions, nColumns) {
+		return Object.keys(data).map((key) => {
+			const image = data[key];
+			const imageSizedForColumn =
+				  this._resizeByColumns(data[key].dimensions, parentDimensions, nColumns);
+			// Return a image object that width will be equivilent to
+			// the column dimension, while retaining original image properties
+			return {
+  				...image,
+  				...imageSizedForColumn
+			};
+		});
+	}
 
-  // Resize image while maintain aspect ratio
-  // _resizeByColumns :: ImgDimensions , parentDimensions, nColumns  -> AdjustedDimensions
-  _resizeByColumns (imgDimensions = { width: 0, height: 0 }, parentDimensions, nColumns=2) {
-    const { height, width } = parentDimensions;
+	// Resize image while maintain aspect ratio
+	// _resizeByColumns :: ImgDimensions , parentDimensions, nColumns  -> AdjustedDimensions
+	_resizeByColumns (imgDimensions = { width: 0, height: 0 }, parentDimensions, nColumns=2) {
+		const { height, width } = parentDimensions;
 
-    // The gutter is 1% of the available view width
-    const gutterBase = width / 100;
-    const gutterSize = gutterBase * this.props.spacing;
+		// The gutter is 1% of the available view width
+		const gutterBase = width / 100;
+		const gutterSize = gutterBase * this.props.spacing;
 
-    // Column gutters are shared between right and left image
-    const columnWidth = (width / nColumns) - (gutterSize / 2);
+		// Column gutters are shared between right and left image
+		const columnWidth = (width / nColumns) - (gutterSize / 2);
 
-    if (this.state.columnWidth !== columnWidth) {
-      this.setState({
-        columnWidth
-      });
-    }
+		if (this.state.columnWidth !== columnWidth) {
+			this.setState({
+				columnWidth
+			});
+		}
 
-    const divider = imgDimensions.width / columnWidth;
+		const divider = imgDimensions.width / columnWidth;
 
-    const newWidth = imgDimensions.width / divider;
-    const newHeight = imgDimensions.height / divider;
+		const newWidth = imgDimensions.width / divider;
+		const newHeight = imgDimensions.height / divider;
 
-    return { width: newWidth, height: newHeight, gutter: gutterSize };
-  }
+		return { width: newWidth, height: newHeight, gutter: gutterSize };
+	}
 
-  // Renders the "bricks" within the columns
-  // _renderBrick :: images -> [TouchableTag || ImageTag...]
-  _renderBrick = (data) => {
-      // Example Data Structure
-      // {
-      //   "item": {
-      //     "uri": "https://img.buzzfeed.com/buzzfeed-static/static/2016-01/14/20/campaign_images/webdr15/which-delicious-mexican-food-item-are-you-based-o-2-20324-1452822970-1_dblbig.jpg",
-      //     "column": 0,
-      //     "dimensions": {
-      //       "width": 625,
-      //       "height": 415
-      //     },
-      //     "width": 180.675,
-      //     "height": 119.96820000000001,
-      //     "gutter": 3.65
-      //   },
-      //   "index": 9
-      // }
-      const brick = data.item;
-      const gutter = (data.index === 0) ? 0 : brick.gutter;
-      const key = `RN-MASONRY-BRICK-${brick.column}-${data.index}`;
-      const { imageContainerStyle, customImageComponent, customImageProps } = this.props;
-      const props = { ...brick, gutter, key, imageContainerStyle, customImageComponent, customImageProps };
+	// Renders the "bricks" within the columns
+	// _renderBrick :: images -> [TouchableTag || ImageTag...]
+	_renderBrick = (data) => {
+		// Example Data Structure
+		// {
+		//   "item": {
+		//     "uri": "https://img.buzzfeed.com/buzzfeed-static/static/2016-01/14/20/campaign_images/webdr15/which-delicious-mexican-food-item-are-you-based-o-2-20324-1452822970-1_dblbig.jpg",
+		//     "column": 0,
+		//     "dimensions": {
+		//       "width": 625,
+		//       "height": 415
+		//     },
+		//     "width": 180.675,
+		//     "height": 119.96820000000001,
+		//     "gutter": 3.65
+		//   },
+		//   "index": 9
+		// }
+		const brick = data.item;
+		const gutter = (data.index === 0) ? 0 : brick.gutter;
+		const key = `RN-MASONRY-BRICK-${brick.column}-${data.index}`;
+		const { imageContainerStyle, customImageComponent, customImageProps } = this.props;
+		const props = { ...brick, gutter, key, imageContainerStyle, customImageComponent, customImageProps };
 
-      return (
-        <Brick
-          {...props} />
-      );
-  }
+		return (
+			<Brick
+			  {...props} />
+		);
+	}
 
-  // _keyExtractor :: item -> id
-  _keyExtractor = (item) => ("IMAGE-KEY-" + item.uri + "---" + (item.key ? item.key : "0"));
+	// _keyExtractor :: item -> id
+	_keyExtractor = (item) => ("IMAGE-KEY-" + item.uri + "---" + (item.key ? item.key : "0"));
 
-  render() {
-    return (
-      <View
-        style={[
-          {
-            width: this.state.columnWidth,
-            overflow: 'hidden'
-          },
-          styles.masonry__column
-        ]}>
-        <FlatList
-          key={this.props.columnKey}
-          data={this.state.images}
-          keyExtractor={this._keyExtractor}
-          renderItem={this._renderBrick}
-        />
-      </View>
-    )
-  }
+	render() {
+		return (
+			<View
+			  style={[
+				  {
+					  width: this.state.columnWidth,
+					  overflow: 'hidden'
+				  },
+				  styles.masonry__column
+			  ]}>
+			  <FlatList
+				key={this.props.columnKey}
+				data={this.state.images}
+				keyExtractor={this._keyExtractor}
+				renderItem={this._renderBrick}
+				/>
+			</View>
+		)
+	}
 }

--- a/components/Masonry.js
+++ b/components/Masonry.js
@@ -20,148 +20,138 @@ export const assignObjectIndex = (index, targetObject) => ({...targetObject, ...
 const containMatchingUris = (r1, r2) => isEqual(r1.map(brick => brick.uri), r2.map(brick => brick.uri));
 
 export default class Masonry extends Component {
-  static propTypes = {
-    bricks: PropTypes.array,
-    columns: PropTypes.number,
-    sorted: PropTypes.bool,
-    imageContainerStyle: PropTypes.object,
-    customImageComponent: PropTypes.func,
-    customImageProps: PropTypes.object,
-    spacing: PropTypes.number
-  };
+	static propTypes = {
+		bricks: PropTypes.array,
+		columns: PropTypes.number,
+		sorted: PropTypes.bool,
+		imageContainerStyle: PropTypes.object,
+		customImageComponent: PropTypes.func,
+		customImageProps: PropTypes.object,
+		spacing: PropTypes.number
+	};
 
-  static defaultProps = {
-    bricks: [],
-    columns: 2,
-    sorted: false,
-    imageContainerStyle: {},
-    spacing: 1
-  };
+	static defaultProps = {
+		bricks: [],
+		columns: 2,
+		sorted: false,
+		imageContainerStyle: {},
+		spacing: 1
+	};
 
-  constructor(props) {
-    super(props);
-    // Assuming users don't want duplicated images, if this is not the case we can always change the diff check
-    this.ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => !containMatchingUris(r1, r2) });
-    this.state = {
-      dataSource: this.ds.cloneWithRows([]),
-      dimensions: {},
-      initialOrientation: true,
-      _sortedData: [],
-      _resolvedData: []
-    };
-    // Assuming that rotation is binary (vertical|landscape)
-    Dimensions.addEventListener('change', (window) => this.setState(state => ({ initialOrientation: !state.initialOrientation })))
-  }
+	constructor(props) {
+		super(props);
+		// Assuming users don't want duplicated images, if this is not the case we can always change the diff check
+		this.ds = new ListView.DataSource({ rowHasChanged: (r1, r2) => !containMatchingUris(r1, r2) });
+		this.state = {
+			dataSource: this.ds.cloneWithRows([]),
+			dimensions: {},
+			initialOrientation: true,
+			_sortedData: [],
+			_resolvedData: []
+		};
+		// Assuming that rotation is binary (vertical|landscape)
+		Dimensions.addEventListener('change', (window) => this.setState(state => ({ initialOrientation: !state.initialOrientation })))
+	}
 
-  componentDidMount() {
-    this.resolveBricks(this.props);
-  }
+	componentDidMount() {
+		this.resolveBricks(this.props);
+	}
 
-  componentWillReceiveProps(nextProps) {
-    const sameData = containMatchingUris(this.props.bricks, nextProps.bricks);
-    if (sameData) {
-      const differentColumns = this.props.columns !== nextProps.columns;
+	componentWillReceiveProps(nextProps) {
+		const sameData = containMatchingUris(this.props.bricks, nextProps.bricks);
+		const differentColumns = this.props.columns !== nextProps.columns;
 
-      if (differentColumns) {
-        const newColumnCount = nextProps.columns;
-        // Re-sort existing data instead of attempting to re-resolved
-        const resortedData = this.state._resolvedData
-          .map((brick, index) => assignObjectColumn(newColumnCount, index, brick))
-          .map((brick, index) => assignObjectIndex(index, brick))
-          .reduce((sortDataAcc, resolvedBrick) => _insertIntoColumn(resolvedBrick, sortDataAcc, this.props.sorted), []);
+		if (sameData && !differentColumns) {
+			// Only re-render a portion of the bricks
+			this.resolveBricks(nextProps, true);
+		} else {
+			this.resolveBricks(nextProps);
+		}
+	}
 
-        this.setState({
-          dataSource: this.state.dataSource.cloneWithRows(resortedData)
-        });
-      }
-    } else {
-    this.resolveBricks(nextProps, true);
-    }
-  }
+	resolveBricks({ bricks, columns }, partiallyCache = false) {
+		// Sort bricks and place them into their respectable columns
+		const sortedBricks = bricks
+			  .map((brick, index) => assignObjectColumn(columns, index, brick))
+			.map((brick, index) => assignObjectIndex(index, brick));
 
-  resolveBricks({ bricks, columns }, newBricks = false) {
-    // Sort bricks and place them into their respectable columns
-    const sortedBricks = bricks
-      .map((brick, index) => assignObjectColumn(columns, index, brick))
-      .map((brick, index) => assignObjectIndex(index, brick));
+		// Do a difference check if these are new props
+		// to only resolve what is needed
+		const unresolvedBricks = (partiallyCache) ?
+			differenceBy(sortedBricks, this.state._resolvedData, 'uri') :
+			sortedBricks;
 
-    // Do a difference check if these are new props
-    // to only resolve what is needed
-    const unresolvedBricks = (newBricks) ?
-      differenceBy(sortedBricks, this.state._resolvedData, 'uri') :
-      sortedBricks;
+		unresolvedBricks
+			.map(brick => resolveImage(brick))
+			.map(resolveTask => resolveTask.fork(
+				(err) => console.warn('Image failed to load'),
+				(resolvedBrick) => {
+					this.setState(state => {
+						const sortedData = _insertIntoColumn(resolvedBrick, state._sortedData, this.props.sorted);
 
-    unresolvedBricks
-      .map(brick => resolveImage(brick))
-      .map(resolveTask => resolveTask.fork(
-        (err) => console.warn('Image failed to load'),
-        (resolvedBrick) => {
-          this.setState(state => {
-            const sortedData = _insertIntoColumn(resolvedBrick, state._sortedData, this.props.sorted);
+						return {
+							dataSource: state.dataSource.cloneWithRows(sortedData),
+							_sortedData: sortedData,
+							_resolvedData: [...state._resolvedData, resolvedBrick]
+						};
+					});;
+				}));
+	}
 
-            return {
-              dataSource: state.dataSource.cloneWithRows(sortedData),
-              _sortedData: sortedData,
-              _resolvedData: [...state._resolvedData, resolvedBrick]
-            };
-          });;
-        }));
-  }
+	_setParentDimensions(event) {
+		// Currently height isn't being utilized, but will pass through for future features
+		const {width, height} = event.nativeEvent.layout;
 
-  _setParentDimensions(event) {
-    // Currently height isn't being utilized, but will pass through for future features
-    const {width, height} = event.nativeEvent.layout;
+		this.setState({
+			dimensions: {
+				width,
+				height
+			}
+		});
+	}
 
-    this.setState({
-      dimensions: {
-        width,
-        height
-      }
-    });
-  }
-
-  render() {
-    return (
-    <View style={{flex: 1}} onLayout={(event) => this._setParentDimensions(event)}>
-       <ListView
-         contentContainerStyle={styles.masonry__container}
-         dataSource={this.state.dataSource}
-         enableEmptySections
-         renderRow={(data, sectionId, rowID) =>
-           <Column
-             data={data}
-             columns={this.props.columns}
-             parentDimensions={this.state.dimensions}
-             imageContainerStyle={this.props.imageContainerStyle}
-             customImageComponent={this.props.customImageComponent}
-             customImageProps={this.props.customImageProps}
-             spacing={this.props.spacing}
-             key={`RN-MASONRY-COLUMN-${rowID}`}/> }
-       />
-    </View>
-    )
-  }
+	render() {
+		return (
+			<View style={{flex: 1}} onLayout={(event) => this._setParentDimensions(event)}>
+			  <ListView
+				contentContainerStyle={styles.masonry__container}
+				dataSource={this.state.dataSource}
+				enableEmptySections
+				renderRow={(data, sectionId, rowID) =>
+						   <Column
+								 data={data}
+								 columns={this.props.columns}
+								 parentDimensions={this.state.dimensions}
+								 imageContainerStyle={this.props.imageContainerStyle}
+								 customImageComponent={this.props.customImageComponent}
+								 customImageProps={this.props.customImageProps}
+								 spacing={this.props.spacing}
+							 key={`RN-MASONRY-COLUMN-${rowID}`}/> }
+						   />
+			</View>
+		)
+	}
 };
 
 // Returns a copy of the dataSet with resolvedBrick in correct place
 // (resolvedBrick, dataSetA, bool) -> dataSetB
 export function _insertIntoColumn (resolvedBrick, dataSet, sorted) {
-  let dataCopy = dataSet.slice();
-  const columnIndex = resolvedBrick.column;
-  const column = dataSet[columnIndex];
+	let dataCopy = dataSet.slice();
+	const columnIndex = resolvedBrick.column;
+	const column = dataSet[columnIndex];
 
-  if (column) {
-    // Append to existing "row"/"column"
-    const bricks = [...column, resolvedBrick];
-    if (sorted) {
-      // Sort bricks according to the index of their original array position
-      bricks = bricks.sort((a, b) => (a.index < b.index) ? -1 : 1);
-    }
-    dataCopy[columnIndex] = bricks;
-  } else {
-    // Pass it as a new "row" for the data source
-    dataCopy = [...dataCopy, [resolvedBrick]];
-  }
+	if (column) {
+		// Append to existing "row"/"column"
+		const bricks = [...column, resolvedBrick];
+		if (sorted) {
+			// Sort bricks according to the index of their original array position
+			bricks = bricks.sort((a, b) => (a.index < b.index) ? -1 : 1);
+		}
+		dataCopy[columnIndex] = bricks;
+	} else {
+		// Pass it as a new "row" for the data source
+		dataCopy = [...dataCopy, [resolvedBrick]];
+	}
 
-  return dataCopy;
+	return dataCopy;
 };

--- a/components/model.js
+++ b/components/model.js
@@ -3,12 +3,12 @@ import Task from 'data.task';
 
 // resolveImage :: String -> Task(Error, Image)
 export const resolveImage = (data) => {
-  return new Task((reject, resolve) => Image.getSize(data.uri, (width, height) => resolve({
-    ...data,
-    //@TODO: Consider consolidating data.uri with dimensions to a image object
-    dimensions: {
-      width,
-      height
-    }
-  }), (err) => reject(err)));
+	return new Task((reject, resolve) => Image.getSize(data.uri, (width, height) => resolve({
+		...data,
+		//@TODO: Consider consolidating data.uri with dimensions to a image object
+		dimensions: {
+			width,
+			height
+		}
+	}), (err) => reject(err)));
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-masonry",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A react-native component for a masonry layout",
   "main": "./components/Masonry.js",
   "scripts": {


### PR DESCRIPTION
## Changes Done
- Caching logic done within `Masonry.js` LOC 60 - 70. 
- Fix indentation to reflect rjsx-mode within emacs

## Fixes issue #70 
> Main issue stemmed from caching not recalculatings bricks that had different columns, but same data. This resulted in improper placement for views that returned back into a view. Typically this issue would not be seen if a component is always re-rendered on entering scene.

## Results
If masonry notices different columns, immediately perform recalculations (let default caching of system handle image aspect). If the columns are the same and same data, then optimize the calculations by only performing it on blocks that have not be resolved. 
  