### PR TITLE
Add empty array check

### DIFF
--- a/components/Masonry.js
+++ b/components/Masonry.js
@@ -59,6 +59,13 @@ export default class Masonry extends Component {
 	}
 
 	componentWillReceiveProps(nextProps) {
+		// Check if it's array and contains more than 1 item
+		if (!Array.isArray(nextProps.bricks) || nextProps.bricks.length === 0) {
+			this.setState(state => ({
+				dataSource: state.dataSource.cloneWithRows([])
+			}));
+		}
+
 		const sameData = containMatchingUris(this.props.bricks, nextProps.bricks);
 		const differentColumns = this.props.columns !== nextProps.columns;
 


### PR DESCRIPTION
This fixes reload issues when the dataset is empty and expects the datastore to be cleared.