### PR TITLE
Passed data to customImageComponent

### DIFF
--- a/components/Brick.js
+++ b/components/Brick.js
@@ -24,6 +24,9 @@ export function _getImageTag (props, gutter = 0) {
 		source: {
 			uri: props.uri
 		},
+		data: {
+			...props.data
+		},
 		resizeMethod: 'auto',
 		style: {
 			width: props.width,


### PR DESCRIPTION
This allows one pass custom data into customImageComponent, just like renderHeader and renderFooter. This also fixes #53 because one could pass custom dimensions in the data attribute and also fixes #75 because you can pass key in the data attribute as well.