### PR TITLE
Allow to render Header and Footer components

### DIFF
--- a/components/Masonry.js
+++ b/components/Masonry.js
@@ -28,7 +28,9 @@ export default class Masonry extends Component {
 		customImageComponent: PropTypes.func,
 		customImageProps: PropTypes.object,
 		spacing: PropTypes.number,
-		refreshControl: PropTypes.element
+		renderHeader: PropTypes.func,
+		renderFooter: PropTypes.func,
+		refreshControl: PropTypes.element,
 	};
 
 	static defaultProps = {
@@ -125,6 +127,8 @@ export default class Masonry extends Component {
 				contentContainerStyle={styles.masonry__container}
 				dataSource={this.state.dataSource}
 				enableEmptySections
+				renderHeader={this.props.renderHeader}
+				renderFooter={this.props.renderFooter}
 				renderRow={(data, sectionId, rowID) =>
 						   <Column
 								 data={data}

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,8 @@
 | customImageComponent | `React.Component` | Use a custom component to be rendered for the Image. This will work properly, as long as the component follows the standard interface of the react-native image component.                      | n/a     |
 | customImageProps     | object            | Pass along additional properties to a `props.customImageComponent`.                                                                                                                             | n/a     |
 | spacing              | num               | Gutter size of the column. The spacing is a multiplier of 1% of the available view.                                                                                                             | 1       |
+| renderHeader       | func | Allow to render a `React.Component` at the top of the list | n/a     |
+| renderFooter       | func | Allow to render a `React.Component` at the bottom of the list | n/a     |
 | refreshControl       | `React.Component` | A component to be used as a refresh element for the Masonry component                                                                                                                           | n/a     |
 ### Brick Properties
 "Bricks" are the basic building block of the masonry and are passed into the props.bricks. They essentially represent the items within each column and require a `uri` property at a minimum. However, you can freely add additional properties to the `data` property if you need access to certain data within your `brick.onPress` handler and `footer/header` renderer. The following properties are available.


### PR DESCRIPTION
This PR exposes the `renderHeader` and `renderFooter` props from [ListView](https://facebook.github.io/react-native/docs/listview#renderfooter) component.